### PR TITLE
Use $ENV{USERPROFILE} instead of $ENV{HOME} on Windows

### DIFF
--- a/modules/UseAndroid.cmake
+++ b/modules/UseAndroid.cmake
@@ -28,7 +28,11 @@ cmake_minimum_required(VERSION 3.7) # Android support is since 3.7
 
 # Override this to point to your debug.keystore location (and specify a
 # password)
-set(ANDROID_APKSIGNER_KEY --ks $ENV{HOME}/.android/debug.keystore --ks-pass pass:android CACHE STRING "")
+if(WINDOWS)
+    set(ANDROID_APKSIGNER_KEY --ks $ENV{USERPROFILE}/.android/debug.keystore --ks-pass pass:android CACHE STRING "")
+else()
+    set(ANDROID_APKSIGNER_KEY --ks $ENV{HOME}/.android/debug.keystore --ks-pass pass:android CACHE STRING "")
+endif()
 
 # Path to Android SDK. The build-tools/ subdirectory must exist.
 if(NOT ANDROID_SDK)


### PR DESCRIPTION
Hi @mosra !

As requested, here are the changes to fix location of the keystore on windows.

Cheers, Jonathan.