### PR TITLE
emscripten: Remove linker only flag from compiler flags

### DIFF
--- a/generic/Emscripten-wasm.cmake
+++ b/generic/Emscripten-wasm.cmake
@@ -74,7 +74,6 @@ set(CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_FIND_ROOT_PATH})
 # compiler and linker. The *_INIT variables are available since CMake 3.7, so
 # it won't work in earlier versions. Sorry.
 cmake_minimum_required(VERSION 3.7)
-set(CMAKE_CXX_FLAGS_INIT "-s WASM=1")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-s WASM=1")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "-DNDEBUG -O3")
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE_INIT "-O3 --llvm-lto 1")


### PR DESCRIPTION
Hi @mosra !

This is a tiny one: Newer emscripten versions produce a loud warning when using linker-only flags during compilation:

```
em++: warning: linker setting ignored during compilation: 'WASM' [-Wunused-command-line-argument]
```

I went ahead and removed it from `CMAKE_CXX_FLAGS_INIT`. 

Best,
Jonathan